### PR TITLE
Add default container includes file

### DIFF
--- a/linkfiles/Makefile.container.includes
+++ b/linkfiles/Makefile.container.includes
@@ -1,0 +1,5 @@
+# Container-specific variables, uncomment and set before performing container builds!
+
+# CONTAINER_REGISTRY ?= some.registry.com
+# CONTAINER_IMAGE_NAME ?= mycontainer
+# CONTAINER_IMAGE_VERSION ?= 0.0.0

--- a/tasks/containers/Makefile
+++ b/tasks/containers/Makefile
@@ -13,6 +13,9 @@ FIND ?= find
 
 # Variables
 
+CONTAINER_INCLUDES_FILE = Makefile.container.includes
+-include $(CONTAINER_INCLUDES_FILE)
+
 CONFTEST_POLICY_DIRECTORIES ?= $(MODULE_DIR)/policy
 DOCKER_BUILD_ARCH ?= linux/amd64,linux/arm64
 


### PR DESCRIPTION
This needs to live with the component, not in the manifests repo. Manifest repo will be updated to pull this file into the root automatically.