### PR TITLE
Splits make check into two subtargets

### DIFF
--- a/tasks/containers/Makefile
+++ b/tasks/containers/Makefile
@@ -59,8 +59,8 @@ docker/build : docker/check-env-vars
 docker/push : docker/build
 	$(DOCKER) buildx build --platform $(DOCKER_BUILD_ARCH) $(BUILD_ARGS) -t $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_VERSION) --push .
 
-.PHONY: check
-check::
+.PHONY: test
+test::
 	$(MAKE) docker/build
 
 .PHONY: docker_compose/start

--- a/tasks/golang/Makefile
+++ b/tasks/golang/Makefile
@@ -11,6 +11,7 @@ FIND ?= find
 # Variables
 
 GO_TEST_DIRECTORIES ?= tests
+GO_TEST_TIMEOUT ?= 2h
 GOLANGCI_LINT_CONFIG ?= .golangci.yaml
 DISABLE_MAKE_CHECK_LINT ?= false
 
@@ -25,7 +26,7 @@ endef
 
 # Check for Go files. If they exist, run tests.
 define go_test
-	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GO) test -v ./$(1)/...;
+	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GO) test -v -timeout=$(GO_TEST_TIMEOUT) ./$(1)/...;
 
 endef
 
@@ -39,16 +40,14 @@ go/lint :
 go/test :
 	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_test,$(test_dir)))
 
-# This is a special declaration
-# Whenever check is defined, it must be defined with a ::
-# _all_ check targets that are found will be run
-# https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html
-# "check" is a GNU Make pattern that runs tests on configured software
-.PHONY: check
-check::
+
+.PHONY: lint
+lint::
 ifeq ($(DISABLE_MAKE_CHECK_LINT),false)
 	$(MAKE) go/lint
 else
 	$(info "make go/lint has been disabled!")
-endif
+
+.PHONY: test
+test:: tfmodule/plan
 	$(MAKE) go/test


### PR DESCRIPTION
Changes the `check` target for a container into a `test` target, as it could lead to malicious code being executed within the container context.

Additionally, synchronizes changes from the lcaf-component-tf-module around `go test` timeout. I am not sure if this is currently used or a vestigial code path, if it's the latter I'll submit another PR to clean this up (go-related `make` targets really belong in a top-level `lcaf-platform-golang` component which does not yet exist).

Will be tagged `0.2.0` upon merge.